### PR TITLE
RuntimeError instead of Exception

### DIFF
--- a/lib/bitwarden.rb
+++ b/lib/bitwarden.rb
@@ -19,7 +19,7 @@ require "pbkdf2"
 require "openssl"
 
 class Bitwarden
-  class InvalidCipherString < Exception; end
+  class InvalidCipherString < RuntimeError; end
 
   # convenience methods for hashing/encryption/decryption that the apps do,
   # just so we can test against


### PR DESCRIPTION
The default exception class for rescue clauses is `StandardError` so it's better to inherit from `RuntimeError` or `StandardError` instead of `Exception`. See https://stackoverflow.com/a/10048406 for a more in-depth explanation.

Great work by the way. I'm enjoying reading through the code.