### PR TITLE
Added types to list of unimplemented 1password/bitwarden fields and 

### DIFF
--- a/tools/1password_import.rb
+++ b/tools/1password_import.rb
@@ -76,7 +76,12 @@ end
 @master_key = Bitwarden.makeKey(password, @u.email)
 
 def encrypt(str)
-  @u.encrypt_data_with_master_password_key(str, @master_key)
+	if str.nil?
+		print "Tried to encrypt nil string, skipping\n"
+	else
+		@u.encrypt_data_with_master_password_key(str, @master_key)
+	end
+
 end
 
 to_save = {}
@@ -144,10 +149,15 @@ File.read(file).split("\n").each do |line|
 
   when "identities.Identity",
   "system.folder.Regular",
-  "wallet.computer.License"
+	"wallet.computer.License",
+	"wallet.government.SsnUS",
+	"wallet.financial.BankAccountUS",
+	"wallet.government.DriversLicense",
+	"wallet.computer.UnixServer",
+	"wallet.computer.Database"
     puts "skipping #{i["typeName"]} #{i["title"]}"
     skipped += 1
-    next
+		next
 
   else
     raise "unimplemented: #{i["typeName"].inspect}"


### PR DESCRIPTION
null check to fix runtime null errors.  These are a few errors I ran into while converting my 1password vault with over 1200 items.  Hopefully these were helpful.  I didn't go as far as trying to convert these values and should come back to add them at some point, but was mostly concerned about getting my login credentials converted over.