### PR TITLE
Require "rotp" for `verifies_totp_code?`.

### DIFF
--- a/lib/user.rb
+++ b/lib/user.rb
@@ -14,6 +14,8 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+require "rotp"
+
 class User < DBModel
   set_table_name "users"
   set_primary_key "uuid"


### PR DESCRIPTION
My installation needed this for TOTP authentication to work properly.