### PR TITLE
Add password hint email support

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -17,4 +17,16 @@
 require File.dirname(__FILE__) + "/lib/bitwarden_ruby.rb"
 require "#{APP_ROOT}/lib/api.rb"
 
+# Parameters to pass to Net::SMTP.start, for sending password hint emails.
+# if :tls is true, we'll attempt to set up a TLS connection to the server; if
+# :starttls is true, we'll try to use STARTTLS after the connection is
+# established.
+#
+# set smtp: {
+#   address: "localhost",
+#   port: 25
+# }
+#
+# set :smtp_from, "nobody@localhost"
+
 run Sinatra::Application


### PR DESCRIPTION
This adds initial support for the `BASE_URI/accounts/password-hint` API, so a user can ask for their password hint to be emailed to them.

It looks for two new Sinatra settings:
* smtp: a hash defining smtp server configuration
* smtp_from: the email address messages should appear to be from

I have some misgivings about this, as I'm not terribly confident about multithreaded behavior in a request handler, but this appears to do the right thing under both successful and error conditions under rack, so I'm putting it up for review. (For a project with more moving parts, I'd farm this out to a work queue, but I intentionally wanted to keep this simple, especially since this is a pretty minor bit of functionality.)

Suggestions are definitely welcome here.