### PR TITLE
Skip additional types in 1Password import tool

### DIFF
--- a/tools/1password_import.rb
+++ b/tools/1password_import.rb
@@ -187,7 +187,14 @@ File.read(file).split("\n").each do |line|
   "system.folder.Regular",
   "system.folder.SavedSearch",
   "wallet.computer.License",
-  "wallet.computer.UnixServer"
+  "wallet.computer.UnixServer",
+  "wallet.computer.License",
+  "wallet.government.SsnUS",
+  "wallet.financial.BankAccountUS",
+  "wallet.government.DriversLicense",
+  "wallet.membership.Membership",
+  "wallet.onlineservices.Email.v2",
+  "wallet.computer.Database"
     puts "skipping #{i["typeName"]} #{i["title"]}"
     skipped += 1
     next


### PR DESCRIPTION
Split off from https://github.com/jcs/bitwarden-ruby/pull/12 and added further types found on my import while fixing the review remarks.

Does not include the nil check from https://github.com/jcs/bitwarden-ruby/pull/12, will comment over there.