### PR TITLE
Fix invalid present check in 1Password import

### DIFF
--- a/tools/1password_import.rb
+++ b/tools/1password_import.rb
@@ -162,7 +162,7 @@ File.read(file).split("\n").each do |line|
     if i["secureContents"]["cardholder"].present?
       cdata["CardholderName"] = encrypt(i["secureContents"]["cardholder"])
     end
-    if i["secureContents"]["cardholder"].present?
+    if i["secureContents"]["type"].present?
       cdata["Brand"] = encrypt(i["secureContents"]["type"])
     end
     if i["secureContents"]["ccnum"].present?


### PR DESCRIPTION
The TypeError exception ocurring in encrypt is caused by a wrong check
here: https://github.com/jcs/bitwarden-ruby/blob/master/tools/1password_import.rb#L165-L166

Backtrace during importing my 1pif file:

```
 #<TypeError: no implicit conversion of nil into String>
~/dev/bitwarden-ruby/lib/bitwarden.rb:70:in `update'
~/dev/bitwarden-ruby/lib/bitwarden.rb:70:in `encrypt'
~/dev/bitwarden-ruby/lib/user.rb:53:in
`encrypt_data_with_master_password_key'
tools/1password_import.rb:80:in `encrypt'
tools/1password_import.rb:169:in `block in <main>'
tools/1password_import.rb:128:in `each'
tools/1password_import.rb:128:in `<main>'
```

Fixes the remainder of https://github.com/jcs/bitwarden-ruby/pull/12