### PR TITLE
Encryption and Decryption use the secret symetric key

### DIFF
--- a/spec/cipherstring_spec.rb
+++ b/spec/cipherstring_spec.rb
@@ -47,7 +47,8 @@ describe "bitwarden encryption stuff" do
 
   it "should encrypt and decrypt properly" do
     ik = Bitwarden.makeKey("password", "user@example.com")
-    k = Bitwarden.makeEncKey(ik)
+    ek = Bitwarden.makeEncKey(ik)
+    k = Bitwarden.decrypt(ek, ik, nil)
     j = Bitwarden.encrypt("hi there", k[0, 32], k[32, 32])
 
     cs = Bitwarden::CipherString.parse(j)


### PR DESCRIPTION
Previous example use the public encrypted key as symetric key to encrypt and decrypt in the tests.

Now the secret symetric key is decoded with the master_key (derived from email and password). This is the key that is used to encrypt and decrypt.

It probably won't change the issue of the test itself (anything of the correct size could be used as a key) but it won't confuse the readers about the real key usage.