### PR TITLE
Migrate to new data layout to work with upstream clients

### DIFF
--- a/API.md
+++ b/API.md
@@ -137,14 +137,19 @@ Each cipher has a number of key/value pairs, with some values being encrypted:
 		"notes":"2.NLkXMHtgR8u9azASR4XPOQ==|6/9QPcnoeQJDKBZTjcBAjVYJ7U/ArTch0hUSHZns6v8=|p55cl9FQK/Hef+7yzM7Cfe0w07q5hZI9tTbxupZepyM=",
 		"favorite": false,
 		"login": {
-			"uri": "2.6DmdNKlm3a+9k/5DFg+pTg==|7q1Arwz/ZfKEx+fksV3yo0HMQdypHJvyiix6hzgF3gY=|7lSXqjfq5rD3/3ofNZVpgv1ags696B2XXJryiGjDZvk=",
+			"uris": [
+				{
+					"uri": "2.6DmdNKlm3a+9k/5DFg+pTg==|7q1Arwz/ZfKEx+fksV3yo0HMQdypHJvyiix6hzgF3gY=|7lSXqjfq5rD3/3ofNZVpgv1ags696B2XXJryiGjDZvk=",
+					"match": null
+				}
+			],
 			"username": "2.4Dwitdv4Br85MABzhMJ4hg==|0BJtHtXbfZWwQXbFcBn0aA==|LM4VC+qNpezmub1f4l1TMLDb9g/Q+sIis2vDbU32ZGA=",
 			"password": "2.OOlWRBGib6G8WRvBOziKzQ==|Had/obAdd2/6y4qzM1Kc/A==|LtHXwZc5PkiReFhkzvEHIL01NrsWGvintQbmqwxoXSI=",
 			"totp": null
 		}
 	}
 
-The values for `name`, `notes`, `login.uri`, `login.username`, and
+The values for `name`, `notes`, `login.uris[0].uri`, `login.username`, and
 `login.password` are each encrypted as "CipherString" values, with the
 leading `2` indicating its type (`AesCbc256_HmacSha256_B64`).
 
@@ -416,15 +421,20 @@ A successful response will contain a JSON body with `Profile`, `Folders`,
 				"Id": "0f01a66f-7802-42bc-9647-a82600f11e10",
 				"OrganizationId": null,
 				"Type":1,
-				"Data":{
-					"Uri": "2.6DmdNKlm3a+9k/5DFg+pTg==|7q1Arwz/ZfKEx+fksV3yo0HMQdypHJvyiix6hzgF3gY=|7lSXqjfq5rD3/3ofNZVpgv1ags696B2XXJryiGjDZvk=",
+				"Login":{
+					"Uris": [
+						{
+							"Uri": "2.6DmdNKlm3a+9k/5DFg+pTg==|7q1Arwz/ZfKEx+fksV3yo0HMQdypHJvyiix6hzgF3gY=|7lSXqjfq5rD3/3ofNZVpgv1ags696B2XXJryiGjDZvk=",
+							"Match": null,
+						},
+					],
 					"Username": "2.4Dwitdv4Br85MABzhMJ4hg==|0BJtHtXbfZWwQXbFcBn0aA==|LM4VC+qNpezmub1f4l1TMLDb9g/Q+sIis2vDbU32ZGA=",
 					"Password":"2.OOlWRBGib6G8WRvBOziKzQ==|Had/obAdd2/6y4qzM1Kc/A==|LtHXwZc5PkiReFhkzvEHIL01NrsWGvintQbmqwxoXSI=",
 					"Totp":null,
-					"Name": "2.zAgCKbTvGowtaRn1er5WGA==|oVaVLIjfBQoRr5EvHTwfhQ==|lHSTUO5Rgfkjl3J/zGJVRfL8Ab5XrepmyMv9iZL5JBE=",
-					"Notes": "2.NLkXMHtgR8u9azASR4XPOQ==|6/9QPcnoeQJDKBZTjcBAjVYJ7U/ArTch0hUSHZns6v8=|p55cl9FQK/Hef+7yzM7Cfe0w07q5hZI9tTbxupZepyM=",
-					"Fields": null
 				},
+				"Name": "2.zAgCKbTvGowtaRn1er5WGA==|oVaVLIjfBQoRr5EvHTwfhQ==|lHSTUO5Rgfkjl3J/zGJVRfL8Ab5XrepmyMv9iZL5JBE=",
+				"Notes": "2.NLkXMHtgR8u9azASR4XPOQ==|6/9QPcnoeQJDKBZTjcBAjVYJ7U/ArTch0hUSHZns6v8=|p55cl9FQK/Hef+7yzM7Cfe0w07q5hZI9tTbxupZepyM=",
+				"Fields": null,
 				"Attachments": null,
 				"OrganizationUseTotp": false,
 				"RevisionDate": "2017-11-09T14:37:52.9033333",
@@ -509,15 +519,20 @@ cipher data:
 		"Id": "4c2869dd-0e1c-499f-b116-a824016df251",
 		"OrganizationId": null,
 		"Type": 1,
-		"Data": {
-			"Uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
-			"Username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
-			"Password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
-			"Totp": null,
-			"Name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
-			"Notes": null,
-			"Fields": null
+		"Login": {
+			"Uris": [
+				{
+					"Uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+					"Match": null,
+				},
+			],
 		},
+		"Username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"Password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"Totp": null,
+		"Name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+		"Notes": null,
+		"Fields": null,
 		"Attachments": null,
 		"OrganizationUseTotp": false,
 		"RevisionDate": "2017-11-07T22:12:22.235914Z",

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -111,47 +111,28 @@ class Cipher < DBModel
     self.notes = params[:notes]
 
     self.fields = nil
-    if params[:fields]
-      # we have to ucfirst each key of each field in the array
-      tfields = []
-      params[:fields].each do |f|
-        tf = {}
-        f.each do |k,v|
-          tf[k.to_s.ucfirst] = v
-        end
-        tfields.push tf
-      end
-      self.fields = tfields.to_json
+    if params[:fields] && params[:fields].is_a?(Array)
+      self.fields = params[:fields].map{|h| h.ucfirst_hash }.to_json
     end
 
     case self.type
     when TYPE_LOGIN
-      tlogin = {}
-      params[:login].each do |k,v|
-        tlogin[k.to_s.ucfirst] = v
+      tlogin = params[:login].ucfirst_hash
+
+      if tlogin["Uris"] && tlogin["Uris"].is_a?(Array)
+        tlogin["Uris"].map!{|h| h.ucfirst_hash }
       end
+
       self.login = tlogin.to_json
 
     when TYPE_NOTE
-      tnote = {}
-      params[:securenote].each do |k,v|
-        tnote[k.to_s.ucfirst] = v
-      end
-      self.securenote = tnote.to_json
+      self.securenote = params[:securenote].ucfirst_hash.to_json
 
     when TYPE_CARD
-      tcard = {}
-      params[:card].each do |k,v|
-        tcard[k.to_s.ucfirst] = v
-      end
-      self.card = tcard.to_json
+      self.card = params[:card].ucfirst_hash.to_json
 
     when TYPE_IDENTITY
-      tid = {}
-      params[:identity].each do |k,v|
-        tid[k.to_s.ucfirst] = v
-      end
-      self.identity = tid.to_json
+      self.identity = params[:identity].ucfirst_hash.to_json
     end
   end
 

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -20,9 +20,10 @@ class Cipher < DBModel
 
   attr_writer :user
 
-  TYPE_LOGIN = 1
-  TYPE_NOTE  = 2
-  TYPE_CARD  = 3
+  TYPE_LOGIN    = 1
+  TYPE_NOTE     = 2
+  TYPE_CARD     = 3
+  TYPE_IDENTITY = 4
 
   def self.type_s(type)
     case type
@@ -32,6 +33,8 @@ class Cipher < DBModel
       "note"
     when TYPE_CARD
       "card"
+    when TYPE_IDENTITY
+      "identity"
     else
       type.to_s
     end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -14,6 +14,16 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+class Sinatra::IndifferentHash
+  def ucfirst_hash
+    out = {}
+    self.each do |k,v|
+      out[k.to_s.downcase.ucfirst] = v
+    end
+    out
+  end
+end
+
 class NilClass
   def blank?
     true


### PR DESCRIPTION
See #32 for more information.

To try this branch:

- Backup your `production.sqlite3` database in case of problems (`cp db/production.sqlite3 db/production-backup.sqlite3`)
- Fetch this pull request to your local Git tree:
`git fetch origin refs/pull/36/head:pr/36`
- Switch to this PR:
`git checkout pr/36`
- Restart your Rack server.  If using Unicorn, send it a SIGUSR2.
- As soon as the server restarts, it should migrate to the new schema and you should see this in your logs:
````
migrating db from version 2
migrated all ciphers to new dedicated fields
````
- The updated upstream Bitwarden clients should just work, though you may want to force a sync from the Settings tab.