### PR TITLE
ucfirst_hash should not downcase full key

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -18,7 +18,7 @@ class Sinatra::IndifferentHash
   def ucfirst_hash
     out = {}
     self.each do |k,v|
-      out[k.to_s.downcase.ucfirst] = v
+      out[k.to_s.ucfirst] = v
     end
     out
   end


### PR DESCRIPTION
While working on the active-record integration i noticed that it didn't display the cardholder name for a card entry. After checking the database and seeing that the cardholder name value got saved, I checked what the client sent (firefox browser client) and noticed that it sent the name camelCased, with a lower-case starting letter. After playing around a little bit, i found out that it wants the name to stay CamelCased, but with a upper-case starting letter.

So a bit more technical:

Client sends:

```
...
card: {
  "cardholderName": "Some Name",
  "expMonth": "XXX",
...
}
```
and wants as a response:

```
...
card: {
  "CardholderName": "Some Name",
  "ExpMonth": "XXX",
...
}
```

But right now the ucfirst_hash method downcases the full key and therefore turns ```cardholderName``` into ```Cardholdername```, where it should be ```CardholderName```. 

I only checked with cards. As a second step, since the data is still in the database, one could write a quick script to restore the most common keys to proper casing :-)