### PR TITLE
Adds Passport type to skip in 1P importer

### DIFF
--- a/tools/1password_import.rb
+++ b/tools/1password_import.rb
@@ -190,6 +190,7 @@ File.read(file).split("\n").each do |line|
   "wallet.computer.UnixServer",
   "wallet.computer.License",
   "wallet.government.SsnUS",
+  "wallet.government.Passport",
   "wallet.financial.BankAccountUS",
   "wallet.government.DriversLicense",
   "wallet.membership.Membership",


### PR DESCRIPTION
The "Passport" type in a 1pif file makes the import script abort. It should just skip it, like it does for bank accounts.

```
tools/1password_import.rb:204:in `block in <main>': unimplemented: "wallet.government.Passport" (RuntimeError)
	from tools/1password_import.rb:125:in `each'
	from tools/1password_import.rb:125:in `<main>'
```

This PR just makes it skip Passports like the other data types that don't have analogs in Bitwarden.